### PR TITLE
Add missing dependency to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This ensures that all dependencies are satisfied on Ubuntu/Debian
 
     sudo apt-get update
     sudo apt-get install python-bs4 python-pip python git
-    sudo pip install selenium
+    sudo pip install selenium requests
     git clone https://github.com/akurtovic/InstaRaider
     cd InstaRaider
 


### PR DESCRIPTION
I added the python `requests` library to the installation instructions found in the README. 

Forgetting to install this dependency causes the following error:

```
$ python instaRaider.py -h
Traceback (most recent call last):
  File "instaRaider.py", line 15, in <module>
    import requests
ImportError: No module named requests
```

For more info: http://stackoverflow.com/questions/17309288/importerror-no-module-named-requests
