### PR TITLE
Set file modification time to photo timestamp on save

### DIFF
--- a/instaRaider.py
+++ b/instaRaider.py
@@ -12,7 +12,9 @@ import logging
 import os
 import os.path as op
 import re
+import email.utils as eut
 import requests
+import calendar
 try:
     from requests.packages.urllib3.exceptions import InsecurePlatformWarning
 except ImportError:
@@ -180,6 +182,10 @@ class InstaRaider(object):
         image_data = image_request.content
         with open(photo_name, 'wb') as fp:
             fp.write(image_data)
+
+        if "last-modified" in image_request.headers:
+            modtime = calendar.timegm(eut.parsedate(image_request.headers["last-modified"]))
+            os.utime(photo_name, (modtime, modtime))
 
     def download_photos(self):
         """


### PR DESCRIPTION
Hello,

When downloading images and trying to find a specific image, I've found that it helps me to sort them when the downloaded image has the same modification time as when the file was uploaded to Instagram. So e.g. if the file was uploaded on January 1 2014 then I set the downloaded image to the same modification time. Instagram already sets the "Last-Modified" header on the response so it was pretty easy.

This is my first time writing Python so my apologies if it's not too clean :) Maybe it should be a command-line option?
