### PR TITLE
remove (smaller) size factor from URL if present

### DIFF
--- a/instaRaider.py
+++ b/instaRaider.py
@@ -205,6 +205,8 @@ class InstaRaider(object):
         for link in links:
             photo_url = link[5:]
             photo_url = photo_url.replace('\\', '')
+            photo_url = re.sub(r'/s\d+x\d+/', '/', photo_url)
+
             split = urlparse.urlsplit(photo_url)
             photo_name = op.join(self.directory, split.path.split("/")[-1])
 


### PR DESCRIPTION
Hello, one more small fix. Instagram has started allowing full-size photos up to 1080x1080 but for some reason they scale these down for some requests (can't tell if it's based on window size, user agent etc.) by inserting a string like "/s640x640/" into the URL, e.g.:

(scaled down) https://scontent-iad3-1.cdninstagram.com/hphotos-xaf1/s640x640/t51.2885-15/e35/11934697_164681077205358_1909607832_n.jpg

vs.

(full size) https://scontent-iad3-1.cdninstagram.com/hphotos-xaf1/t51.2885-15/e35/11934697_164681077205358_1909607832_n.jpg

This just removes the "size" component so images are always downloaded at full res.
