### PR TITLE
Add support for automated login and multiple usernames

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,21 +29,21 @@ sudo pip install -u selenium
 The first time you use InstaRaider for a specific username, it will download all the photos on that user's profile.
 On subsequent uses, InstaRaider will only download new photos (unless you rename or remove the photos from the Images directory for that specific username). 
 ```python
-usage: instaRaider.py [-h] [-n imageCount] USERNAME ./DIRECTORY/TO/SAVE/IMAGES
+usage: instaRaider.py [-h] [-n imageCount] ~/JSON/FILE/CONTAINING/USERNAMES ./DIRECTORY/TO/SAVE/IMAGES
 ```
 
 ### Output:
 ```
-$ python instaRaider.py -n 100 username ./images/username
+$ python instaRaider.py -n 100 usersnames.json ./instagram/images
 username has 263 posts on Instagram.
 The first 100 of them will be downloaded.
 Loading Instagram profile...
-Saving photos to ./images/username
+Saving photos to ./instagram/images/username
 Downloaded file 1/100 (123.jpg).
 Downloaded file 2/100 (456.jpg).
 ...
 Downloaded file 100/100 (789.jpg).
-Saved 100 files to ./images/username
+Saved 100 files to ./instagram/images/username
 ```
 ### Multiprocessing performance
 After 3 independent tests ran on the same machine, for a profile with 565 posts, the script took the following time to run depending on the number of processes ran:

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(
             'instaraider = instaraider:main',
         ],
     ),
-    install_requires=['requests', 'selenium'],
+    install_requires=['requests', 'selenium', 'awesome-slugify'],
 )


### PR DESCRIPTION
I am not sure if this PR is going to be merged as it diverges a lot from the original interface. But I don't want people to have to go to forks for this functionality. There are two main features in this PR:
- Originally, InstaRaider only allows downloading images for one user at a time. This PR allow giving a json file containing usernames and downloading photos/videos for them. Now it does not take `username` as command argument. 
- Due to above feature, it is not ideal for the end-user to keep manually logging-in everytime a private profile is found. I have added two optional arguments: `username` and `password`, which will be used to login into instagram automatically.

Also, I had to change a check for private profile.

Let me know your thoughts
